### PR TITLE
Start on Simplifying Save Process and Fix "segment" Capitialization Error

### DIFF
--- a/SmashHitEditorProject/Assets/Scripts/Data.cs
+++ b/SmashHitEditorProject/Assets/Scripts/Data.cs
@@ -14,42 +14,15 @@ public class Data : MonoBehaviour
     public void Save()
     {
         /*This function saves to .xml*/
-
         
-        #region format segment size
-        /*This formats the segment size to a string in the smash hit size format*/
-        string sx, sy, sz;
-        if (seg.s.x == Mathf.RoundToInt(seg.s.x))
-        {
-            sx = seg.s.x + ".0";
-        }
-        else
-        {
-            sx = seg.s.x + "";
-        }
-        if (seg.s.y == Mathf.RoundToInt(seg.s.y))
-        {
-            sy = seg.s.y + ".0";
-        }
-        else
-        {
-            sy = seg.s.y + "";
-        }
-        if (seg.s.z == Mathf.RoundToInt(seg.s.z))
-        {
-            sz = seg.s.z + ".0";
-        }
-        else
-        {
-            sz = seg.s.z + "";
-        }
-        seg.size = sx + " " + sy + " " + sz;
-        #endregion
+        // Convert the segment size to a string
+        seg.size = seg.s.x + " " + seg.s.y + " " + seg.s.z;
+        
         foreach (Box b in seg.box)
         {
             /*This loop loops over the box array in seg and formats the size and position of each box
-             we do this to make it easier to work with the size and position of the boxs while in the
-             editor*/
+            we do this to make it easier to work with the size and position of the boxs while in the
+            editor*/
             string x;
             string y;
             string z;

--- a/SmashHitEditorProject/Assets/Scripts/Data.cs
+++ b/SmashHitEditorProject/Assets/Scripts/Data.cs
@@ -7,13 +7,12 @@ using UnityEngine;
 
 public class Data : MonoBehaviour
 {
-    [XmlElement("Segment")]
-    public Segment seg;
-
+    [XmlElement("segment")] // this doesn't seem to work
+    public segment seg;
     
     public void Save()
     {
-        /*This function saves to .xml*/
+        /* This function saves to a .xml file. */
         
         // Convert the segment size to a string
         seg.size = seg.s.x + " " + seg.s.y + " " + seg.s.z;

--- a/SmashHitEditorProject/Assets/Scripts/Data.cs
+++ b/SmashHitEditorProject/Assets/Scripts/Data.cs
@@ -7,8 +7,8 @@ using UnityEngine;
 
 public class Data : MonoBehaviour
 {
-    [XmlElement("segment")] // this doesn't seem to work
-    public segment seg;
+    [XmlElement("segment")]
+    public Segment seg;
     
     public void Save()
     {

--- a/SmashHitEditorProject/Assets/Scripts/XMLClasses/Segment.cs
+++ b/SmashHitEditorProject/Assets/Scripts/XMLClasses/Segment.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.Xml.Serialization;
+
 [System.Serializable]
-public class Segment { 
+public class segment { 
+    /* This class name needs to be lower case otherwise the XML searializer
+     * thinks that Segment should be capitialized, which doesn't work. */
     [XmlIgnore]
     public string Name;
 

--- a/SmashHitEditorProject/Assets/Scripts/XMLClasses/Segment.cs
+++ b/SmashHitEditorProject/Assets/Scripts/XMLClasses/Segment.cs
@@ -4,9 +4,7 @@ using UnityEngine;
 using System.Xml.Serialization;
 
 [System.Serializable]
-public class segment { 
-    /* This class name needs to be lower case otherwise the XML searializer
-     * thinks that Segment should be capitialized, which doesn't work. */
+public class Segment { 
     [XmlIgnore]
     public string Name;
 

--- a/SmashHitEditorProject/Assets/Shaders.meta
+++ b/SmashHitEditorProject/Assets/Shaders.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a925d6bb60dccfb46baa2b835dfd7432
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Changes in this PR:

- A temporary fix for the "segment" tag being capitalised. (Maybe someone knows a better way to do this?)
- Started to simplify the save process by not worrying if the value is floating point or not. (Smash Hit will accept either one.)

Note: This is my first PR, please point out any issues.